### PR TITLE
Create React SSR base project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.dist
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-store
+.DS_Store
+dist/public/assets/client.js

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# codex-v1
+# React SSR Base
+
+This repository contains a minimal server-side rendered (SSR) React starter. It provides:
+
+- An Express server that renders React components on the server.
+- Hydration on the client using React 18 APIs.
+- An ESBuild-based client bundle with zero-configuration Babel setup for server-side JSX.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+The development server starts on [http://localhost:3000](http://localhost:3000). Changes in `server/` or `src/` automatically restart the server via `nodemon`.
+
+## Production build
+
+```bash
+npm run build
+npm start
+```
+
+The build command bundles the client assets into `dist/public/assets`. The Express server serves the pre-built assets and renders the initial HTML on the server.
+
+## Project structure
+
+```
+├── dist/                 # Output directory for built assets
+├── server/               # Express server and SSR entry point
+├── src/
+│   ├── client/           # Client hydration entry
+│   └── shared/           # React components shared by server and client
+├── package.json
+└── babel.config.cjs
+```
+
+Feel free to extend the starter by adding routing, state management, or API integrations.

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: { node: 'current' }
+      }
+    ],
+    [
+      '@babel/preset-react',
+      {
+        runtime: 'automatic'
+      }
+    ]
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "react-ssr-base",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "nodemon --watch server --watch src --ext js,jsx --exec \"node server/index.js\"",
+    "build": "npm run build:client",
+    "build:client": "esbuild src/client/index.jsx --bundle --sourcemap --outfile=dist/public/assets/client.js --public-path=/assets --loader:.js=jsx --loader:.jsx=jsx",
+    "start": "NODE_ENV=production node server/index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.5",
+    "@babel/preset-env": "^7.24.5",
+    "@babel/preset-react": "^7.24.5",
+    "@babel/register": "^7.24.1",
+    "esbuild": "^0.20.2",
+    "nodemon": "^3.1.0"
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,53 @@
+const path = require('path');
+const express = require('express');
+
+require('@babel/register')({
+  extensions: ['.js', '.jsx'],
+  presets: [
+    [
+      '@babel/preset-env',
+      { targets: { node: 'current' } }
+    ],
+    [
+      '@babel/preset-react',
+      { runtime: 'automatic' }
+    ]
+  ],
+  ignore: [/node_modules/]
+});
+
+const React = require('react');
+const { renderToString } = require('react-dom/server');
+const App = require('../src/shared/App').default;
+
+const PORT = process.env.PORT || 3000;
+const app = express();
+
+const publicDir = path.resolve(__dirname, '../dist/public');
+app.use('/assets', express.static(path.join(publicDir, 'assets')));
+
+function createHtml(markup) {
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React SSR Base</title>
+    <link rel="icon" href="data:," />
+  </head>
+  <body>
+    <div id="root">${markup}</div>
+    <script type="module" src="/assets/client.js" defer></script>
+  </body>
+</html>`;
+}
+
+app.get('*', (req, res) => {
+  const appHtml = renderToString(React.createElement(App, { url: req.url }));
+  res.status(200).send(createHtml(appHtml));
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on http://localhost:${PORT}`);
+});

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { createRoot, hydrateRoot } from 'react-dom/client';
+import App from '../shared/App.jsx';
+
+const container = document.getElementById('root');
+
+if (container.hasChildNodes()) {
+  hydrateRoot(container, <App />);
+} else {
+  const root = createRoot(container);
+  root.render(<App />);
+}

--- a/src/shared/App.jsx
+++ b/src/shared/App.jsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+
+const messages = [
+  'Welcome to your React SSR base project!',
+  'Edit src/shared/App.jsx to get started.',
+  'Server-rendered markup hydrates on the client.'
+];
+
+export default function App() {
+  const [index, setIndex] = useState(0);
+
+  const nextMessage = () => {
+    setIndex((current) => (current + 1) % messages.length);
+  };
+
+  return (
+    <main style={styles.container}>
+      <h1 style={styles.heading}>React SSR Base</h1>
+      <p style={styles.message}>{messages[index]}</p>
+      <button type="button" onClick={nextMessage} style={styles.button}>
+        Rotate message
+      </button>
+    </main>
+  );
+}
+
+const styles = {
+  container: {
+    minHeight: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: 'linear-gradient(135deg, #0f172a 0%, #1d4ed8 100%)',
+    color: '#f8fafc',
+    fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+    textAlign: 'center',
+    padding: '0 1.5rem'
+  },
+  heading: {
+    fontSize: '3rem',
+    marginBottom: '1rem'
+  },
+  message: {
+    fontSize: '1.25rem',
+    maxWidth: '32rem',
+    marginBottom: '2rem'
+  },
+  button: {
+    padding: '0.75rem 1.5rem',
+    fontSize: '1rem',
+    borderRadius: '9999px',
+    border: 'none',
+    backgroundColor: '#facc15',
+    color: '#0f172a',
+    cursor: 'pointer',
+    fontWeight: 600,
+    transition: 'transform 0.2s ease, box-shadow 0.2s ease'
+  }
+};


### PR DESCRIPTION
## Summary
- scaffold a React 18 server-side rendered starter with Express
- configure Babel for server JSX and esbuild for the client bundle
- document setup, scripts, and project structure in the README

## Testing
- npm install *(fails: registry access forbidden in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4796628d08329802268e5e944c35f